### PR TITLE
Update BVE.R

### DIFF
--- a/R/BVE.R
+++ b/R/BVE.R
@@ -114,8 +114,8 @@ bve_pls <- function( y, X, ncomp=10, ratio=0.75, VIP.threshold=1 ){
     is.selected[variables[VIP.index]] <- F
     variables     <- which( is.selected ) 
     Variable.list <- c(Variable.list, list(variables)) 
-    Zcal  <- Zcal[,VIP.index]
-    Ztest <- Ztest[,VIP.index]
+    Zcal  <- Zcal[, -VIP.index, drop = FALSE]
+    Ztest <- Ztest[, -VIP.index, drop = FALSE]
     indd  <- unique( which(apply(Zcal, 2, var)==0),which(apply(Ztest, 2, var)==0))
     Zcal  <- Zcal[, -indd] 
     Ztest <- Ztest[, -indd] 


### PR DESCRIPTION
VIP elimination step appears inverted (low VIP variables are kept)